### PR TITLE
Fix module name to enable importing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module merkle-patrica-trie
+module github.com/zhangchiqing/merkle-patricia-trie
 
 go 1.18
 


### PR DESCRIPTION
Currently, it is not possible to import this project in a go module, when you try to do that you get this error: 
```bash
go get "github.com/zhangchiqing/merkle-patricia-trie"                                           
go: downloading github.com/zhangchiqing/merkle-patricia-trie v0.0.0-20221001045205-378516ae831b
go: github.com/zhangchiqing/merkle-patricia-trie@upgrade (v0.0.0-20221001045205-378516ae831b) requires github.com/zhangchiqing/merkle-patricia-trie@v0.0.0-20221001045205-378516ae831b: parsing go.mod:
        module declares its path as: merkle-patrica-trie
                but was required as: github.com/zhangchiqing/merkle-patricia-tri
```
This PR fixes that and closes #12 